### PR TITLE
feat: add permit and multicall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 
 env:
   FOUNDRY_PROFILE: ci
@@ -27,6 +32,11 @@ jobs:
           forge --version
           forge build --sizes
         id: build
+
+      - name: Check Lint
+        run: |
+          forge fmt --check
+        id: lint
 
       - name: Run Forge tests
         run: |

--- a/src/Sponsor.sol
+++ b/src/Sponsor.sol
@@ -6,17 +6,17 @@ import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol"
 import {ExecutionLib} from "./lib/ExecutionLib.sol";
 import {SelfOperations} from "./base/SelfOperations.sol";
 import {Conditions} from "./base/Conditions.sol";
+import {Multicall} from "./base/Multicall.sol";
+import {Permit2Setup} from "./base/Permit2Setup.sol";
 import {ConditionType, Condition, Operation, Execution} from "./base/SponsorStructs.sol";
 
 /// @notice a contract that executes signed user token-oriented operations on their behalf
-contract Sponsor is SelfOperations, Conditions {
+contract Sponsor is SelfOperations, Conditions, Multicall, Permit2Setup {
     using ExecutionLib for Execution;
 
     error UserOperationFailed(uint256 i);
     error SponsorOperationFailed(uint256 i);
     error ETHPaymentFailed();
-
-    ISignatureTransfer immutable permit2 = ISignatureTransfer(0x000000000022D473030F116dDEE9F6B43aC78BA3);
 
     /// @notice execute the given user execution by spec, verifying specified conditions afterwards
     ///     pay msg.sender for the effort upon successful execution

--- a/src/base/Multicall.sol
+++ b/src/base/Multicall.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// from: Uniswap/v3-periphery
+pragma solidity ^0.8.0;
+
+import {Validation} from "./Validation.sol";
+
+/// @title Multicall
+/// @notice Enables calling multiple methods in a single call to the contract
+abstract contract Multicall is Validation {
+    /// @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+    /// @dev The `msg.value` should not be trusted for any method callable from multicall.
+    /// @param data The encoded function data for each of the calls to make to this contract
+    /// @return results The results from each of the calls passed in via data
+    function multicall(bytes[] calldata data) public payable returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+            if (!success) {
+                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
+                if (result.length < 68) revert();
+                assembly {
+                    result := add(result, 0x04)
+                }
+                revert(abi.decode(result, (string)));
+            }
+
+            results[i] = result;
+        }
+    }
+
+    /// @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+    /// @dev The `msg.value` should not be trusted for any method callable from multicall.
+    /// @param deadline The timestamp after which this transaction is invalid
+    /// @param data The encoded function data for each of the calls to make to this contract
+    /// @return results The results from each of the calls passed in via data
+    function multicall(uint256 deadline, bytes[] calldata data)
+        external
+        payable
+        checkDeadline(deadline)
+        returns (bytes[] memory)
+    {
+        return multicall(data);
+    }
+
+    /// @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+    /// @dev The `msg.value` should not be trusted for any method callable from multicall.
+    /// @param previousBlockhash The expected parent blockHash
+    /// @param data The encoded function data for each of the calls to make to this contract
+    /// @return results The results from each of the calls passed in via data
+    function multicall(bytes32 previousBlockhash, bytes[] calldata data)
+        external
+        payable
+        checkPreviousBlockhash(previousBlockhash)
+        returns (bytes[] memory)
+    {
+        return multicall(data);
+    }
+}

--- a/src/base/Permit2Setup.sol
+++ b/src/base/Permit2Setup.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// from: Uniswap/v3-periphery
+pragma solidity ^0.8.0;
+
+import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
+
+/// @title Self Permit
+/// @notice Functionality to call permit on any EIP-2612-compliant token for use in the route
+/// @dev These functions are expected to be embedded in multicalls to allow EOAs to approve a contract and call a function
+/// that requires an approval in a single transaction.
+abstract contract Permit2Setup {
+    ISignatureTransfer public immutable permit2 = ISignatureTransfer(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+
+    /// @notice Permits this contract to spend a given token from `owner`
+    /// @dev The `spender` is always address(this).
+    /// @param token The address of the token spent
+    /// @param owner The address who owns the tokens being permitted
+    /// @param value The amount that can be spent of token
+    /// @param deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+    /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+    /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+    /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+    function permit2Setup(address token, address owner, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        public
+        payable
+    {
+        IERC20Permit(token).permit(owner, address(permit2), value, deadline, v, r, s);
+    }
+
+    /// @notice Permits this contract to spend a given token from `owner`
+    /// @dev `spender` is always address(this).
+    /// Can be used instead of #permit2Setup to prevent calls from failing due to a frontrun of a call to #permit2Setup
+    /// @param token The address of the token spent
+    /// @param owner The address who owns the tokens being permitted
+    /// @param value The amount that can be spent of token
+    /// @param deadline A timestamp, the current blocktime must be less than or equal to this timestamp
+    /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+    /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+    /// @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+    function permit2SetupIfNecessary(
+        address token,
+        address owner,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable {
+        if (IERC20(token).allowance(owner, address(permit2)) < value) {
+            permit2Setup(token, owner, value, deadline, v, r, s);
+        }
+    }
+}

--- a/src/base/Validation.sol
+++ b/src/base/Validation.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// from: Uniswap/v3-periphery
+pragma solidity ^0.8.0;
+
+abstract contract Validation {
+    error TransactionExpired();
+    error InvalidBlockHash();
+
+    modifier checkDeadline(uint256 deadline) {
+        if (block.timestamp > deadline) {
+            revert TransactionExpired();
+        }
+        _;
+    }
+
+    modifier checkPreviousBlockhash(bytes32 previousBlockhash) {
+        if (blockhash(block.number - 1) != previousBlockhash) {
+            revert InvalidBlockHash();
+        }
+        _;
+    }
+}

--- a/test/Permit2Setup.t.sol
+++ b/test/Permit2Setup.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
+import {Test} from "forge-std/Test.sol";
+import {Sponsor} from "../src/Sponsor.sol";
+import {MockSwap} from "./util/MockSwap.sol";
+import {Execution, Condition, ConditionType, Operation} from "../src/base/SponsorStructs.sol";
+import {MockERC20} from "./util/MockERC20.sol";
+
+contract Permit2Setup is Test {
+    Sponsor sponsor;
+    MockERC20 token;
+    uint256 privateKey;
+    address owner;
+    address permit2;
+
+    bytes32 constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    function setUp() public {
+        token = new MockERC20("Test", "TEST");
+        privateKey = 0xabcd;
+        owner = vm.addr(privateKey);
+        token.mint(owner, 10 ether);
+        sponsor = new Sponsor();
+        permit2 = address(sponsor.permit2());
+    }
+
+    function testPermit2Setup() public {
+        assertEq(token.allowance(owner, permit2), 0);
+        (uint8 v, bytes32 r, bytes32 s) = getPermit();
+        sponsor.permit2Setup(address(token), owner, 1 ether, block.timestamp, v, r, s);
+        assertEq(token.allowance(owner, permit2), 1 ether);
+    }
+
+    function testPermit2SetupIfNecessary() public {
+        assertEq(token.allowance(owner, permit2), 0);
+        (uint8 v, bytes32 r, bytes32 s) = getPermit();
+        sponsor.permit2SetupIfNecessary(address(token), owner, 1 ether, block.timestamp, v, r, s);
+        assertEq(token.allowance(owner, permit2), 1 ether);
+
+        (v, r, s) = getPermit();
+        sponsor.permit2SetupIfNecessary(address(token), owner, 1 ether, block.timestamp, v, r, s);
+        // shouldnt permit again
+        assertEq(token.allowance(owner, permit2), 1 ether);
+    }
+
+    function getPermit() internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        (v, r, s) = vm.sign(
+            privateKey,
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    token.DOMAIN_SEPARATOR(),
+                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, permit2, 1 ether, 0, block.timestamp))
+                )
+            )
+        );
+    }
+}

--- a/test/Sponsor.t.sol
+++ b/test/Sponsor.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
@@ -41,7 +41,7 @@ contract SponsorTest is Test, DeployPermit2, PermitSignatures {
         mockSwap = new MockSwap();
         tokenA.mint(address(mockSwap), 1 ether);
         tokenB.mint(address(mockSwap), 1 ether);
-        (bool success,) = address(mockSwap).call{ value: 1 ether }("");
+        (bool success,) = address(mockSwap).call{value: 1 ether}("");
         require(success, "MockSwap: ETH transfer failed");
     }
 
@@ -72,7 +72,6 @@ contract SponsorTest is Test, DeployPermit2, PermitSignatures {
 
         operations[1] =
             Operation({to: address(tokenB), data: abi.encodeWithSelector(ERC20.transfer.selector, recipient, 1 ether)});
-
 
         unsigned.tokens = tokens;
         unsigned.operations = operations;
@@ -238,8 +237,7 @@ contract SponsorTest is Test, DeployPermit2, PermitSignatures {
             data: abi.encodeWithSelector(SelfOperations.sweep.selector, address(tokenA), recipient)
         });
 
-        unsigned.payment =
-            ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 1 ether});
+        unsigned.payment = ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 1 ether});
 
         Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
 
@@ -273,8 +271,7 @@ contract SponsorTest is Test, DeployPermit2, PermitSignatures {
             data: abi.encodeWithSelector(ERC20.transfer.selector, address(recipient), 0.9 ether)
         });
 
-        unsigned.payment =
-            ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 0.1 ether});
+        unsigned.payment = ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 0.1 ether});
 
         Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
 
@@ -308,8 +305,7 @@ contract SponsorTest is Test, DeployPermit2, PermitSignatures {
             data: abi.encodeWithSelector(SelfOperations.sweepETH.selector, address(recipient))
         });
 
-        unsigned.payment =
-            ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 0 ether});
+        unsigned.payment = ISignatureTransfer.TokenPermissions({token: address(tokenB), amount: 0 ether});
 
         Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
 

--- a/test/SponsorMulticall.t.sol
+++ b/test/SponsorMulticall.t.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {Sponsor} from "../src/Sponsor.sol";
+import {MockSwap} from "./util/MockSwap.sol";
+import {DeployPermit2} from "./util/DeployPermit2.sol";
+import {SelfOperations} from "../src/base/SelfOperations.sol";
+import {Execution, Condition, ConditionType, Operation} from "../src/base/SponsorStructs.sol";
+import {MockERC20} from "./util/MockERC20.sol";
+import {PermitSignatures, UnsignedExecution} from "./util/PermitSignatures.sol";
+
+contract SponsorMulticallTest is Test, DeployPermit2, PermitSignatures {
+    error TransactionExpired();
+    error InvalidBlockHash();
+
+    bytes4 constant EXECUTE_SELECTOR = bytes4(
+        keccak256(
+            "execute(((address,uint256)[],(address,uint256),(address,bytes)[],(uint8,address,bytes,bytes)[],address,uint256,uint256,bytes))"
+        )
+    );
+    bytes32 constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    address constant recipient = address(1);
+    uint256 constant senderPk = 0x1234;
+    address sender;
+    address operator;
+    Sponsor sponsor;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    MockSwap mockSwap;
+
+    function setUp() public {
+        sender = vm.addr(senderPk);
+        operator = makeAddr("operator");
+        deployPermit2();
+        sponsor = new Sponsor();
+        tokenA = new MockERC20("TokenA", "TA");
+        tokenB = new MockERC20("TokenB", "TB");
+        tokenA.mint(sender, 100 ether);
+        tokenB.mint(sender, 100 ether);
+        mockSwap = new MockSwap();
+        tokenA.mint(address(mockSwap), 1 ether);
+        tokenB.mint(address(mockSwap), 1 ether);
+        (bool success,) = address(mockSwap).call{value: 1 ether}("");
+        require(success, "MockSwap: ETH transfer failed");
+    }
+
+    function testSponsorPermitAndSimpleTransferMulticall() public {
+        UnsignedExecution memory unsigned = buildSimpleExecution();
+        Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
+        (uint8 v, bytes32 r, bytes32 s) = getPermit(tokenA);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            sponsor.permit2Setup.selector, address(tokenA), sender, 1 ether, block.timestamp, v, r, s
+        );
+        calls[1] = abi.encodeWithSelector(EXECUTE_SELECTOR, execution);
+
+        vm.prank(operator);
+        sponsor.multicall(calls);
+
+        assertEq(tokenA.balanceOf(sender), 99 ether);
+        assertEq(tokenA.balanceOf(recipient), 0.9 ether);
+        assertEq(tokenA.balanceOf(operator), 0.1 ether);
+    }
+
+    function testSponsorPermitAndSimpleTransferMulticallWithDeadline() public {
+        UnsignedExecution memory unsigned = buildSimpleExecution();
+        Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
+        (uint8 v, bytes32 r, bytes32 s) = getPermit(tokenA);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            sponsor.permit2Setup.selector, address(tokenA), sender, 1 ether, block.timestamp, v, r, s
+        );
+        calls[1] = abi.encodeWithSelector(EXECUTE_SELECTOR, execution);
+
+        vm.prank(operator);
+        sponsor.multicall(block.timestamp + 1, calls);
+
+        assertEq(tokenA.balanceOf(sender), 99 ether);
+        assertEq(tokenA.balanceOf(recipient), 0.9 ether);
+        assertEq(tokenA.balanceOf(operator), 0.1 ether);
+    }
+
+    function testSponsorPermitAndSimpleTransferMulticallWithDeadlineExpired() public {
+        UnsignedExecution memory unsigned = buildSimpleExecution();
+        Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
+        (uint8 v, bytes32 r, bytes32 s) = getPermit(tokenA);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            sponsor.permit2Setup.selector, address(tokenA), sender, 1 ether, block.timestamp, v, r, s
+        );
+        calls[1] = abi.encodeWithSelector(EXECUTE_SELECTOR, execution);
+
+        vm.prank(operator);
+        vm.expectRevert(TransactionExpired.selector);
+        sponsor.multicall(block.timestamp - 1, calls);
+    }
+
+    function testSponsorPermitAndSimpleTransferMulticallWithBlockHash() public {
+        UnsignedExecution memory unsigned = buildSimpleExecution();
+        Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
+        (uint8 v, bytes32 r, bytes32 s) = getPermit(tokenA);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            sponsor.permit2Setup.selector, address(tokenA), sender, 1 ether, block.timestamp, v, r, s
+        );
+        calls[1] = abi.encodeWithSelector(EXECUTE_SELECTOR, execution);
+
+        vm.prank(operator);
+        sponsor.multicall(blockhash(block.number - 1), calls);
+
+        assertEq(tokenA.balanceOf(sender), 99 ether);
+        assertEq(tokenA.balanceOf(recipient), 0.9 ether);
+        assertEq(tokenA.balanceOf(operator), 0.1 ether);
+    }
+
+    function testSponsorPermitAndSimpleTransferMulticallWithBlockHashInvalid() public {
+        UnsignedExecution memory unsigned = buildSimpleExecution();
+        Execution memory execution = signExecution(unsigned, senderPk, address(sponsor));
+        (uint8 v, bytes32 r, bytes32 s) = getPermit(tokenA);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            sponsor.permit2Setup.selector, address(tokenA), sender, 1 ether, block.timestamp, v, r, s
+        );
+        calls[1] = abi.encodeWithSelector(EXECUTE_SELECTOR, execution);
+
+        vm.prank(operator);
+        vm.expectRevert(InvalidBlockHash.selector);
+        sponsor.multicall(keccak256(hex"10"), calls);
+    }
+
+    function buildSimpleExecution() internal view returns (UnsignedExecution memory unsigned) {
+        ISignatureTransfer.TokenPermissions[] memory tokens = new ISignatureTransfer.TokenPermissions[](1);
+        tokens[0] = ISignatureTransfer.TokenPermissions({token: address(tokenA), amount: 1 ether});
+
+        // pay operator 0.1 tokenB for their effort and gas
+        ISignatureTransfer.TokenPermissions memory payment =
+            ISignatureTransfer.TokenPermissions({token: address(tokenA), amount: 0.1 ether});
+
+        Operation[] memory operations = new Operation[](1);
+        // transfer 0.9 ether to recipient
+        operations[0] = Operation({
+            to: address(tokenA),
+            data: abi.encodeWithSelector(ERC20.transfer.selector, recipient, 0.9 ether)
+        });
+
+        Condition[] memory conditions = new Condition[](0);
+
+        unsigned = UnsignedExecution({
+            tokens: tokens,
+            payment: payment,
+            operations: operations,
+            conditions: conditions,
+            sender: sender,
+            nonce: 0,
+            deadline: block.timestamp + 100
+        });
+    }
+
+    function getPermit(ERC20 token) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        (v, r, s) = vm.sign(
+            senderPk,
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    token.DOMAIN_SEPARATOR(),
+                    keccak256(abi.encode(PERMIT_TYPEHASH, sender, permit2, 1 ether, 0, block.timestamp))
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
This commit adds the ability to perform permit2 setup approvals if the
token supports native permit. It also adds a self-multicall system to
allow for permitting in the same transaction as execution of a meta
transaction
